### PR TITLE
Make barrels also breakable by pickaxe

### DIFF
--- a/common/src/main/resources/data/ironchests/tags/blocks/barrels.json
+++ b/common/src/main/resources/data/ironchests/tags/blocks/barrels.json
@@ -1,0 +1,12 @@
+{
+    "replace": "false",
+    "values": [
+        {"required": false, "id": "ironchests:copper_barrel"},
+        {"required": false, "id": "ironchests:iron_barrel"},
+        {"required": false, "id": "ironchests:gold_barrel"},
+        {"required": false, "id": "ironchests:diamond_barrel"},
+        {"required": false, "id": "ironchests:netherite_barrel"},
+        {"required": false, "id": "ironchests:crystal_barrel"},
+        {"required": false, "id": "ironchests:obsidian_barrel"}
+    ]
+}

--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "#ironchests:chests"
+    "#ironchests:chests",
+    "#ironchests:barrels"
   ]
 }


### PR DESCRIPTION
*I HAVEN'T TESTED THIS*, but it does look straight-forward.

Came here after feedback from AoF7 players.

Just copied what was in 1.19; looked like barrels got left out in 1.20 as far as pickaxe-break-ablity is concerned.

Closes #60 and half of #62
